### PR TITLE
Refactor to support subcommands to initialize or clear any number of Secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,30 +21,38 @@ servicex version
 
 ### Initialization
 
-To set up ServiceX
+The ServiceX CLI can be used to initialize ServiceX as follows:
 
 ```bash
-servicex init [--namespace <namespace>] [--cert-dir <cert dir>] [--webhook <webhook url>]
+servicex init [certs|app|all] [--namespace <namespace>] [--cert-dir <cert dir>] [--webhook <webhook url>]
 ```
 
-#### Installing Certs
+Run `servicex init all` to set up everything, 
+or specify a single component for partial setup (e.g. `servicex init certs`).
 
-By default, it will find certs in `.globus` in your home directory. You can 
+For information on the available options for each component, see below.
+
+#### Grid Certs
+
+By default, the CLI will find certs in `.globus` in your home directory. You can 
 override this by providing a `--cert-dir` command line option.
 
 By default the secret will be created in the `default` namespace. You can
 override this by providing a `--namespace` command line option.
 
-When the script runs it will prompt you for your grid cert passphrase. This 
+You will be prompted for your grid cert passphrase. This 
 will not be echoed to the screen, but will be stored in the Kubernetes Secret.
 
-#### Configuring Registration Webhook
+#### ServiceX App
 
 If the `--webhook` option is provided with a Slack 
 [incoming webhook](https://slack.com/help/articles/115005265063-Incoming-Webhooks-for-Slack) 
-URL, ServiceX will post a message to the Slack channel of your choice upon each new user registration.
-The CLI tool will store the URL in a Secret (default name: `servicex-app-secret`), 
-but you still must enter the name of this Secret in the `values.yaml` file:
+URL, ServiceX will post a message to the Slack channel of your choice 
+upon each new user registration.
+
+The CLI tool will provide environment variables to the ServiceX Flask app in 
+a Secret (default name: `servicex-app-secret`).
+You still must enter the name of this Secret in the `values.yaml` file:
 
 ```yaml
 app:
@@ -52,7 +60,8 @@ app:
   secret: servicex-app-secret
 ```
 
-Now Helm will retrieve this URL and provide it to the ServiceX REST API server (Flask app) upon installation.
+Now Helm will retrieve this URL and provide it to the ServiceX REST API server 
+(Flask app) upon installation.
 
 ### Removal
 
@@ -60,12 +69,10 @@ If you want to remove the installed Secrets from the cluster then
 you can use:
 
 ```bash
-servicex clear [--namespace <namespace>]
+servicex clear [certs|app|all] [--namespace <namespace>]
 ```
 
-This takes the same `--namespace` argument as the `init` command to remove the 
+Run `servicex clear all` to clear all Secrets, or specify a single component 
+(e.g. `servicex clear certs`). This takes the same `--namespace` argument as the `init` command to remove the 
 Secrets from that namespace.
- 
-
-
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ servicex version
 The ServiceX CLI can be used to initialize ServiceX as follows:
 
 ```bash
-servicex init [certs|all] [--namespace <namespace>] [--cert-dir <cert dir>]
+servicex [--namespace <namespace>] init [certs|all] [--cert-dir <cert dir>]
 ```
 
 Run `servicex init` to set up everything, or specify one or more components 
@@ -35,7 +35,8 @@ By default, the CLI will find certs in `.globus` in your home directory. You can
 override this by providing a `--cert-dir` command line option.
 
 By default the secret will be created in the `default` namespace. You can
-override this by providing a `--namespace` command line option.
+override this by providing a `--namespace` command line option 
+(this must precede the `init` command). 
 
 You will be prompted for your grid cert passphrase. This 
 will not be echoed to the screen, but will be stored in the Kubernetes Secret.
@@ -46,11 +47,11 @@ If you want to remove the installed Secrets from the cluster then
 you can use:
 
 ```bash
-servicex clear [certs|all] [--namespace <namespace>]
+servicex [--namespace <namespace>] clear [certs|all]
 ```
 
 Run `servicex clear` to clear all Secrets, or specify one or more components 
 (e.g. `servicex clear certs`).
-This takes the same `--namespace` argument as the `init` command to remove the 
+Specify a `--namespace` argument which precedes the `clear` command to remove the 
 Secrets from that namespace.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # ServiceX Command Line Tool
-This is a tool for setting up the serviceX cluster. 
+This is a tool for setting up the ServiceX cluster. 
 
-Its only function for now is to install your grid certs and passphrase
-securely as kubernetes secrets.
+Currently, its only function is to automatically create
+Kubernetes [Secrets](https://kubernetes.io/docs/concepts/configuration/secret/) 
+to securely store the following:
+- Your grid certs and passphrase
+- Slack webhook URL for new user registration
 
 ## Installation
 The tool is available on pypi so...
@@ -16,11 +19,16 @@ To list the version of the servicex cli installed:
 servicex version
 ```
 
-### Install Certs
-To install your grid certs
+### Initialization
+
+To set up ServiceX
+
 ```bash
-servicex init
+servicex init [--namespace <namespace>] [--cert-dir <cert dir>] [--webhook <webhook url>]
 ```
+
+#### Installing Certs
+
 By default, it will find certs in `.globus` in your home directory. You can 
 override this by providing a `--cert-dir` command line option.
 
@@ -28,17 +36,35 @@ By default the secret will be created in the `default` namespace. You can
 override this by providing a `--namespace` command line option.
 
 When the script runs it will prompt you for your grid cert passphrase. This 
-will not be echoed to the screen, but will be stored in the kubernetes secret.
+will not be echoed to the screen, but will be stored in the Kubernetes Secret.
 
-### Remove Certs
-If you want to remove the installed certs and passphrase from the cluster then
-you can use:
-```bash
-servicex clear
+#### Configuring Registration Webhook
+
+If the `--webhook` option is provided with a Slack 
+[incoming webhook](https://slack.com/help/articles/115005265063-Incoming-Webhooks-for-Slack) 
+URL, ServiceX will post a message to the Slack channel of your choice upon each new user registration.
+The CLI tool will store the URL in a Secret (default name: `servicex-app-secret`), 
+but you still must enter the name of this Secret in the `values.yaml` file:
+
+```yaml
+app:
+  # Name of secret used to populate environment variables
+  secret: servicex-app-secret
 ```
 
-It takes the same `--namespace` argument as the `init` command to remove the 
-secret from that namespace.
+Now Helm will retrieve this URL and provide it to the ServiceX REST API server (Flask app) upon installation.
+
+### Removal
+
+If you want to remove the installed Secrets from the cluster then
+you can use:
+
+```bash
+servicex clear [--namespace <namespace>]
+```
+
+This takes the same `--namespace` argument as the `init` command to remove the 
+Secrets from that namespace.
  
 
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,12 @@
 # ServiceX Command Line Tool
 This is a tool for setting up the ServiceX cluster. 
 
-Currently, its only function is to automatically create
-Kubernetes [Secrets](https://kubernetes.io/docs/concepts/configuration/secret/) 
-to securely store the following:
-- Your grid certs and passphrase
-- Slack webhook URL for new user registration
+Currently, its only function is to automatically create a
+Kubernetes [Secret](https://kubernetes.io/docs/concepts/configuration/secret/) 
+to securely store your grid certs and passphrase, and to clear this Secret.
 
 ## Installation
-The tool is available on pypi so...
+The tool is available on pypi:
 ```bash
 pip install servicex-cli
 ```
@@ -24,13 +22,12 @@ servicex version
 The ServiceX CLI can be used to initialize ServiceX as follows:
 
 ```bash
-servicex init [certs|app|all] [--namespace <namespace>] [--cert-dir <cert dir>] [--webhook <webhook url>]
+servicex init [certs|all] [--namespace <namespace>] [--cert-dir <cert dir>]
 ```
 
-Run `servicex init all` to set up everything, 
-or specify a single component for partial setup (e.g. `servicex init certs`).
-
-For information on the available options for each component, see below.
+Run `servicex init` to set up everything, or specify one or more components 
+for partial setup (e.g. `servicex init certs`).
+Certs are the only component currently supported.
 
 #### Grid Certs
 
@@ -43,36 +40,17 @@ override this by providing a `--namespace` command line option.
 You will be prompted for your grid cert passphrase. This 
 will not be echoed to the screen, but will be stored in the Kubernetes Secret.
 
-#### ServiceX App
-
-If the `--webhook` option is provided with a Slack 
-[incoming webhook](https://slack.com/help/articles/115005265063-Incoming-Webhooks-for-Slack) 
-URL, ServiceX will post a message to the Slack channel of your choice 
-upon each new user registration.
-
-The CLI tool will provide environment variables to the ServiceX Flask app in 
-a Secret (default name: `servicex-app-secret`).
-You still must enter the name of this Secret in the `values.yaml` file:
-
-```yaml
-app:
-  # Name of secret used to populate environment variables
-  secret: servicex-app-secret
-```
-
-Now Helm will retrieve this URL and provide it to the ServiceX REST API server 
-(Flask app) upon installation.
-
 ### Removal
 
 If you want to remove the installed Secrets from the cluster then
 you can use:
 
 ```bash
-servicex clear [certs|app|all] [--namespace <namespace>]
+servicex clear [certs|all] [--namespace <namespace>]
 ```
 
-Run `servicex clear all` to clear all Secrets, or specify a single component 
-(e.g. `servicex clear certs`). This takes the same `--namespace` argument as the `init` command to remove the 
+Run `servicex clear` to clear all Secrets, or specify one or more components 
+(e.g. `servicex clear certs`).
+This takes the same `--namespace` argument as the `init` command to remove the 
 Secrets from that namespace.
 

--- a/src/servicex/servicex.py
+++ b/src/servicex/servicex.py
@@ -111,7 +111,8 @@ def create_app_secret(namespace, secret_name, webhook_url):
                              type='Opaque',
                              metadata=client.V1ObjectMeta(name=secret_name))
     client.CoreV1Api().create_namespaced_secret(namespace=namespace, body=secret)
-    print(f"Successfully created {secret_name}. Please add this to your values.yaml file under `app.secret`.")
+    print(f"Successfully created {secret_name}. "
+          f"Please add this to your values.yaml file under `app.secret`.")
 
 
 def clear_cluster(args):

--- a/src/servicex/servicex.py
+++ b/src/servicex/servicex.py
@@ -77,7 +77,7 @@ def create_certs_secret(namespace, secret_name, cert_dir):
                              metadata=client.V1ObjectMeta(name=secret_name))
 
     client.CoreV1Api().create_namespaced_secret(namespace=namespace, body=secret)
-    print("Successfully created grid-certs-secret.")
+    print(f"Successfully created {secret_name}.")
 
 
 def create_app_secret(namespace, secret_name, webhook_url):
@@ -96,15 +96,25 @@ def create_app_secret(namespace, secret_name, webhook_url):
                              type='Opaque',
                              metadata=client.V1ObjectMeta(name=secret_name))
     client.CoreV1Api().create_namespaced_secret(namespace=namespace, body=secret)
-    print("Successfully created servicex-app-secret.")
+    print(f"Successfully created {secret_name}. Please add this to your values.yaml file under `app.secret`.")
 
 
-def clear_cluster(secret_name, namespace):
+def clear_cluster(namespace):
+    secret_names = [
+        "grid-certs-secret",
+        "servicex-app-secret"
+    ]
+
+    for name in secret_names:
+        clear_secret(namespace, name)
+
+
+def clear_secret(namespace, secret_name):
     try:
         client.CoreV1Api().delete_namespaced_secret(namespace=namespace, name=secret_name)
-        print("Secret cleared")
+        print(f"Cleared {secret_name}.")
     except kubernetes.client.rest.ApiException:
-        print("Empty Cluster. Nothing to do....")
+        print(f"No existing {secret_name} to clear.")
 
 
 def main():
@@ -115,7 +125,7 @@ def main():
         init_cluster(args)
 
     elif args.command == 'clear':
-        clear_cluster("grid-certs-secret", args.namespace)
+        clear_cluster(args.namespace)
 
     elif args.command == 'version':
         print("ServiceX CLI Version " + pkg_resources.get_distribution('servicex-cli').version)

--- a/src/servicex/servicex.py
+++ b/src/servicex/servicex.py
@@ -65,7 +65,7 @@ clear_parser.add_argument("secret",
                           help="Name of secret which should be cleared")
 
 # Version command
-version_parser = subparsers.add_parser("version", help="")
+version_parser = subparsers.add_parser("version")
 
 
 def init_cluster(args):
@@ -134,7 +134,6 @@ def clear_secret(namespace, secret_name):
 def main():
     kubernetes.config.load_kube_config()
     args = parser.parse_args()
-    print(args)
 
     if args.command == 'init':
         init_cluster(args)

--- a/src/servicex/servicex.py
+++ b/src/servicex/servicex.py
@@ -59,6 +59,7 @@ init_parser.add_argument("--cert-dir",
 clear_parser = subparsers.add_parser('clear', help="Clear secret(s)")
 clear_parser.add_argument("secret",
                           default="all",
+                          nargs='*',
                           choices=secret_choices,
                           help="Name of secret which should be cleared")
 

--- a/src/servicex/servicex.py
+++ b/src/servicex/servicex.py
@@ -40,7 +40,8 @@ parser = argparse.ArgumentParser("servicex")
 parser.add_argument('--namespace', "-n",
                     default="default",
                     help="Namespace where secrets should be created")
-subparsers = parser.add_subparsers(dest="command", required=True)
+subparsers = parser.add_subparsers(dest="command")
+subparsers.required = True
 
 # Init command
 init_parser = subparsers.add_parser("init", help="Initialize secret(s)")

--- a/src/servicex/servicex.py
+++ b/src/servicex/servicex.py
@@ -36,8 +36,6 @@ import os.path
 import os
 import getpass
 
-secret_choices = ["certs", "all"]
-
 parser = argparse.ArgumentParser("servicex")
 parser.add_argument('--namespace', "-n",
                     default="default",
@@ -46,10 +44,9 @@ subparsers = parser.add_subparsers(dest="command", required=True)
 
 # Init command
 init_parser = subparsers.add_parser("init", help="Initialize secret(s)")
-init_parser.add_argument('secret',
-                         default="all",
+init_parser.add_argument('secrets',
+                         default=["all"],
                          nargs='*',
-                         choices=secret_choices,
                          help="Secret which should be initialized")
 init_parser.add_argument("--cert-dir",
                          default="~/.globus",
@@ -57,10 +54,9 @@ init_parser.add_argument("--cert-dir",
 
 # Clear command
 clear_parser = subparsers.add_parser('clear', help="Clear secret(s)")
-clear_parser.add_argument("secret",
-                          default="all",
+clear_parser.add_argument("secrets",
+                          default=["all"],
                           nargs='*',
-                          choices=secret_choices,
                           help="Name of secret which should be cleared")
 
 # Version command
@@ -68,8 +64,8 @@ version_parser = subparsers.add_parser("version")
 
 
 def init_cluster(args):
-    namespace, secret = args.namespace, args.secret
-    if secret in ["certs", "all"]:
+    namespace, secrets = args.namespace, args.secrets
+    if "certs" in secrets or "all" in secrets:
         create_certs_secret(namespace, "grid-certs-secret", args.cert_dir)
 
 
@@ -94,8 +90,8 @@ def create_certs_secret(namespace, secret_name, cert_dir):
 
 
 def clear_cluster(args):
-    namespace, secret = args.namespace, args.secret
-    if secret in ["certs", "all"]:
+    namespace, secrets = args.namespace, args.secrets
+    if "certs" in secrets or "all" in secrets:
         clear_secret(namespace, "grid-certs-secret")
 
 


### PR DESCRIPTION
Support creating a Secret named `servicex-app-secret` for the Flask app to store a Slack webhook url using the `--webhook` command-line argument. Related: ssl-hep/ServiceX#158.

Rewrote README to document new functionality.