### PR TITLE
Check that passphrase actually unlocks the users key

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,8 @@ setup(name="servicex-cli",
       test_suite="tests",
       install_requires=[
           "oauthlib==3.1.0",
-          "kubernetes"
+          "kubernetes",
+          "pyopenssl==19.1.0"
       ],
       extras_require={
           'test': ['flake8==3.5',

--- a/src/servicex_cli/servicex.py
+++ b/src/servicex_cli/servicex.py
@@ -88,7 +88,7 @@ def create_certs_secret(namespace, secret_name, cert_dir):
                               base64.b64decode(data['userkey.pem']),
                               passphrase=passphrase.encode('utf8'))
     except Error:
-        print("Passphrase does not unlock key file")
+        print("Passphrase does not unlock key file. Please correct and try again.")
         sys.exit(-1)
 
     secret = client.V1Secret(data=data,


### PR DESCRIPTION
# Problem
There is no validation of the passphrase that the user enters. It is simply stored in the secret. If it doesn't match then there will be errors in x509 proxy service that will be hard to diagnose

Solution to [ServiceX Issue 198](https://github.com/ssl-hep/ServiceX/issues/198)

# Approach
Bring in the pyopenssl library and use it to verify the passphrase can unlock the key file